### PR TITLE
#25 Don't resolve unresolvable configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ sourceCompatibility = 1.7
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    testCompile 'com.netflix.nebula:nebula-test:4.4.3'
+    testCompile 'com.netflix.nebula:nebula-test:5.0.0'
 }
 
 bintray {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ sourceCompatibility = 1.7
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    testCompile 'com.netflix.nebula:nebula-test:4.0.0'
+    testCompile 'com.netflix.nebula:nebula-test:4.4.3'
 }
 
 bintray {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/src/main/groovy/com/palantir/configurationresolver/ResolveConfigurationsTask.groovy
+++ b/src/main/groovy/com/palantir/configurationresolver/ResolveConfigurationsTask.groovy
@@ -22,6 +22,12 @@ public class ResolveConfigurationsTask extends AbstractTask {
     @TaskAction
     public void resolveAllConfigurations() {
         project.configurations.all { configuration ->
+            // New versions of Gradle have unresolvable configurations by default
+            // https://github.com/gradle/gradle/pull/1351
+            if (configuration.metaClass.respondsTo(configuration, "isCanBeResolved") &&
+                !configuration.isCanBeResolved()) {
+              return;
+            }
             configuration.resolve()
         }
     }


### PR DESCRIPTION
Gradle 3.3+ introduces unresolvable configurations by default
(https://github.com/gradle/gradle/pull/1351). Don't try to resolve these
cnofigurations.

Still being built against 2.x for backwards compatibility, but tested
against 3.4-rc1.