### PR TITLE
Update plugin-publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.9.2'
+    id 'com.gradle.plugin-publish' version '0.9.9'
     id 'com.jfrog.bintray' version '1.5'
     id 'com.palantir.configuration-resolver' version '0.0.1'
     id 'com.palantir.flexversion' version '0.9.2'


### PR DESCRIPTION
Hiya, I was doing a scan of the Gradle Plugin Portal and noticed you are using an old version of the `plugin-publish-plugin`.

There was a [bug in versions prior to 0.9.7](https://discuss.gradle.org/t/plugin-authors-please-use-the-latest-plugin-publish-plugin-others-may-result-in-a-broken-upload/23573), where artifacts would silently not be pushed into the repo, which means the latest version of your plugin will not work properly when people apply it to their build.

Upgrading to the latest version of the `plugin-publish-plugin` will fix this, but this will require pushing a new version of your plugin.

1. apply the PR
2. publish a new version of your plugin
3. let us know if you want us to remove the broken version `0.3.0`

Thanks (and sorry about that).

Let us know here [or in the forums](https://discuss.gradle.org/c/help-discuss/plugin-portal) if you need more assistance.