### PR TITLE
update gradle publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.9.2'
+    id 'com.gradle.plugin-publish' version '0.9.10'
     id 'com.jfrog.bintray' version '1.5'
     id 'com.palantir.configuration-resolver' version '0.0.1'
     id 'com.palantir.flexversion' version '0.9.2'


### PR DESCRIPTION
on using gradle plugins dsl, error occurres.

```
$ ./gradlew resolveConfigurations
Download https://plugins.gradle.org/m2/com/palantir/configuration-resolver/com.palantir.configuration-resolver.gradle.plugin/0.3.0/com.palantir.configuration-resolver.gradle.plugin-0.3.0.pom

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'server'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find gradle.plugin.com.palantir.configurationresolver:gradle-configuration-resolver-plugin:0.3.0.
     Searched in the following locations:
         https://plugins.gradle.org/m2/gradle/plugin/com/palantir/configurationresolver/gradle-configuration-resolver-plugin/0.3.0/gradle-configuration-resolver-plugin-0.3.0.pom
         https://plugins.gradle.org/m2/gradle/plugin/com/palantir/configurationresolver/gradle-configuration-resolver-plugin/0.3.0/gradle-configuration-resolver-plugin-0.3.0.jar
     Required by:
         project : > com.palantir.configuration-resolver:com.palantir.configuration-resolver.gradle.plugin:0.3.0

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
```

please update gradle publisher plugin and re-publish this.

see : https://github.com/flyway/flyway/issues/1862