### PR TITLE
Bintray plugin 1.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.gradle.plugin-publish' version '0.10.1'
-    id 'com.jfrog.bintray' version '1.5'
+    id 'com.jfrog.bintray' version '1.8.4'
     id 'com.palantir.configuration-resolver' version '0.0.1'
     id 'com.palantir.git-version' version '0.11.0'
     id 'groovy'


### PR DESCRIPTION
## Before this PR

Publishing is broken with newer gradle: https://circleci.com/gh/palantir/gradle-configuration-resolver-plugin/179

## After this PR

Publishing should work after using latest bintray plugin.