### PR TITLE
Extend DefaultTask instead of AbstractTask; use lazy task creation

### DIFF
--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,20 +1,11 @@
 type: break
 break:
   description: |-
-    Extend DefaultTask instead of AbstractTask; use lazy task creation
+    Have the ResolveConfigurationsTask extend DefaultTask rather than
+    AbstractTask, resolving a deprecation warning seen in Gradle 6.x.
 
-    I noticed the former causing deprecation warnings indicating this
-    won't be possible in Gradle 7.0.
-
-    I also tried setting up cross-version testing in this repo that
-    would catch said deprecation warning, but it ends up running into
-    other deprecations around certain configurations being resolved
-    (which I suspect will just be flipped over to having isCanBeResolved
-    be false in 7.0, and thus will be ignored by this plugin at that
-    time).
-
-    Other modernizations I did sneak in: Lazy task registration and
-    assuming that Configuration#isCanBeResolved exists (it was added
-    in 3.3).
+    Use lazy task creation to register the resolveConfigurations task.
+    This means a Gradle version of at least 4.9 is now required for
+    this plugin.
   links:
   - https://github.com/palantir/gradle-configuration-resolver-plugin/pull/74

--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,20 @@
+type: break
+break:
+  description: |-
+    Extend DefaultTask instead of AbstractTask; use lazy task creation
+
+    I noticed the former causing deprecation warnings indicating this
+    won't be possible in Gradle 7.0.
+
+    I also tried setting up cross-version testing in this repo that
+    would catch said deprecation warning, but it ends up running into
+    other deprecations around certain configurations being resolved
+    (which I suspect will just be flipped over to having isCanBeResolved
+    be false in 7.0, and thus will be ignored by this plugin at that
+    time).
+
+    Other modernizations I did sneak in: Lazy task registration and
+    assuming that Configuration#isCanBeResolved exists (it was added
+    in 3.3).
+  links:
+  - https://github.com/palantir/gradle-configuration-resolver-plugin/pull/74

--- a/src/main/groovy/com/palantir/configurationresolver/ConfigurationResolverPlugin.groovy
+++ b/src/main/groovy/com/palantir/configurationresolver/ConfigurationResolverPlugin.groovy
@@ -31,7 +31,7 @@ class ConfigurationResolverPlugin implements Plugin<Project> {
             }
         }
 
-        project.tasks.create("resolveConfigurations", ResolveConfigurationsTask.class)
+        project.tasks.register("resolveConfigurations", ResolveConfigurationsTask.class)
     }
 
 }

--- a/src/main/groovy/com/palantir/configurationresolver/ResolveConfigurationsTask.groovy
+++ b/src/main/groovy/com/palantir/configurationresolver/ResolveConfigurationsTask.groovy
@@ -14,18 +14,17 @@
 
 package com.palantir.configurationresolver
 
-import org.gradle.api.internal.AbstractTask
+import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-public class ResolveConfigurationsTask extends AbstractTask {
+public class ResolveConfigurationsTask extends DefaultTask {
 
     @TaskAction
     public void resolveAllConfigurations() {
         project.configurations.all { configuration ->
             // New versions of Gradle have unresolvable configurations by default
             // https://github.com/gradle/gradle/pull/1351
-            if (configuration.metaClass.respondsTo(configuration, "isCanBeResolved") &&
-                !configuration.isCanBeResolved()) {
+            if (!configuration.isCanBeResolved()) {
               return;
             }
             configuration.resolve()


### PR DESCRIPTION
I noticed the former causing deprecation warnings indicating this
won't be possible in Gradle 7.0.

I also tried setting up cross-version testing in this repo that
would catch said deprecation warning, but it ends up running into
other deprecations around certain configurations being resolved
(which I suspect will just be flipped over to having isCanBeResolved
be false in 7.0, and thus will be ignored by this plugin at that
time).

Other modernizations I did sneak in: Lazy task registration and
assuming that Configuration#isCanBeResolved exists (it was added
in 3.3).